### PR TITLE
mpcd reverse perturbation

### DIFF
--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -15,6 +15,7 @@ set(_mpcd_cc_sources
     ManualVirtualParticleFiller.cc
     ParallelPlateGeometryFiller.cc
     PlanarPoreGeometryFiller.cc
+    ReverseNonequilibriumShearFlow.cc
     Sorter.cc
     SRDCollisionMethod.cc
     StreamingMethod.cc
@@ -41,6 +42,8 @@ set(_mpcd_headers
     ParallelPlateGeometryFiller.h
     PlanarPoreGeometryFiller.h
     RejectionVirtualParticleFiller.h
+    ReverseNonequilibriumShearFlow.h
+    ReverseNonequilibriumShearFlowUtilities.h
     Sorter.h
     SRDCollisionMethod.h
     StreamingMethod.h
@@ -265,6 +268,7 @@ set(files
     methods.py
     stream.py
     tune.py
+    update.py
     )
 install(FILES ${files} DESTINATION ${PYTHON_SITE_INSTALL_DIR}/mpcd)
 copy_files_to_build("${files}" "mpcd" "*.py")

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -76,6 +76,7 @@ if(ENABLE_HIP)
         CommunicatorGPU.cc
         ParallelPlateGeometryFillerGPU.cc
         PlanarPoreGeometryFillerGPU.cc
+        ReverseNonequilibriumShearFlowGPU.cc
         SorterGPU.cc
         SRDCollisionMethodGPU.cc
         )
@@ -84,6 +85,8 @@ if(ENABLE_HIP)
         ATCollisionMethodGPU.h
         BounceBackNVEGPU.cuh
         BounceBackNVEGPU.h
+        BounceBackStreamingMethodGPU.cuh
+        BounceBackStreamingMethodGPU.h
         BulkStreamingMethodGPU.h
         CellCommunicator.cuh
         CellThermoComputeGPU.cuh
@@ -92,15 +95,15 @@ if(ENABLE_HIP)
         CellListGPU.h
         CommunicatorGPU.cuh
         CommunicatorGPU.h
-        BounceBackStreamingMethodGPU.cuh
-        BounceBackStreamingMethodGPU.h
-        ParticleData.cuh
         ParallelPlateGeometryFillerGPU.cuh
         ParallelPlateGeometryFillerGPU.h
+        ParticleData.cuh
         PlanarPoreGeometryFillerGPU.cuh
         PlanarPoreGeometryFillerGPU.h
         RejectionVirtualParticleFillerGPU.cuh
         RejectionVirtualParticleFillerGPU.h
+        ReverseNonequilibriumShearFlowGPU.cuh
+        ReverseNonequilibriumShearFlowGPU.h
         SorterGPU.cuh
         SorterGPU.h
         SRDCollisionMethodGPU.cuh
@@ -116,6 +119,7 @@ if(ENABLE_HIP)
         ParallelPlateGeometryFillerGPU.cu
         PlanarPoreGeometryFillerGPU.cu
         RejectionVirtualParticleFillerGPU.cu
+        ReverseNonequilibriumShearFlowGPU.cu
         SorterGPU.cu
         SRDCollisionMethodGPU.cu
         )

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlow.cc
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlow.cc
@@ -1,0 +1,410 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file ReverseNonequilibriumShearFlow.cc
+ * \brief Definition of reverse nonequilibrium shear flow updater
+ */
+
+#include <algorithm>
+
+#include "ReverseNonequilibriumShearFlow.h"
+#include "ReverseNonequilibriumShearFlowUtilities.h"
+
+namespace hoomd
+    {
+/*!
+ * \param sysdata MPCD system data this updater will act on
+ * \param num_swap Max number of swaps
+ * \param slab_width Slab width
+ * \param target_momentum Target momentum in x-direction for the two slabs
+ */
+mpcd::ReverseNonequilibriumShearFlow::ReverseNonequilibriumShearFlow(
+    std::shared_ptr<SystemDefinition> sysdef,
+    std::shared_ptr<Trigger> trigger,
+    unsigned int num_swap,
+    Scalar slab_width,
+    Scalar target_momentum)
+    : Updater(sysdef, trigger), m_mpcd_pdata(sysdef->getMPCDParticleData()), m_num_swap(num_swap),
+      m_slab_width(slab_width), m_summed_momentum_exchange(0), m_num_lo(0),
+      m_particles_lo(m_exec_conf), m_num_hi(0), m_particles_hi(m_exec_conf),
+      m_target_momentum(target_momentum), m_update_slabs(true)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing ReverseNonequilibriumShearFlow" << std::endl;
+
+    m_pdata->getBoxChangeSignal()
+        .connect<mpcd::ReverseNonequilibriumShearFlow,
+                 &mpcd::ReverseNonequilibriumShearFlow::requestUpdateSlabs>(this);
+
+    GPUArray<Scalar2> particles_staged(2 * m_num_swap, m_exec_conf);
+    m_particles_staged.swap(particles_staged);
+    }
+
+mpcd::ReverseNonequilibriumShearFlow::~ReverseNonequilibriumShearFlow()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying ReverseNonequilibriumShearFlow" << std::endl;
+    m_pdata->getBoxChangeSignal()
+        .disconnect<mpcd::ReverseNonequilibriumShearFlow,
+                    &mpcd::ReverseNonequilibriumShearFlow::requestUpdateSlabs>(this);
+    }
+
+/*!
+ * \param num_swap Max number of swaps
+ */
+void mpcd::ReverseNonequilibriumShearFlow::setNumSwap(unsigned int num_swap)
+    {
+    if (num_swap > m_num_swap)
+        {
+        GPUArray<Scalar2> particles_staged(2 * num_swap, m_exec_conf);
+        m_particles_staged.swap(particles_staged);
+        }
+    m_num_swap = num_swap;
+    }
+
+//! Set the target momentum
+void mpcd::ReverseNonequilibriumShearFlow::setTargetMomentum(Scalar target_momentum)
+    {
+    m_target_momentum = target_momentum;
+    }
+
+/*!
+ * \param slab_width Slab width
+ */
+void mpcd::ReverseNonequilibriumShearFlow::setSlabWidth(Scalar slab_width)
+    {
+    m_slab_width = slab_width;
+    requestUpdateSlabs();
+    }
+
+void mpcd::ReverseNonequilibriumShearFlow::setSlabs()
+    {
+    const BoxDim& global_box = m_pdata->getGlobalBox();
+    if (m_slab_width > Scalar(0.5) * global_box.getL().y)
+        {
+        throw std::runtime_error("Slab width cannot be larger than Ly/2");
+        }
+
+    const Scalar3 global_lo = global_box.getLo();
+    m_pos_lo = make_scalar2(global_lo.y, global_lo.y + m_slab_width);
+    m_pos_hi = make_scalar2(Scalar(0.0), m_slab_width);
+    }
+
+/*!
+ * \param timestep Current time step of the simulation
+ */
+void mpcd::ReverseNonequilibriumShearFlow::update(uint64_t timestep)
+    {
+    // if slabs have changed, update them
+    if (m_update_slabs)
+        {
+        setSlabs();
+        m_update_slabs = false;
+        }
+
+    findSwapParticles();
+    stageSwapParticles();
+    swapParticleMomentum();
+    }
+
+/*!
+ * Finds all particles in the "lower" and "upper" slab in y direction and
+ * puts them into two GPUArrays, sorted by their momentum closest to -/+ target_momentum in x
+ * direction.
+ */
+void mpcd::ReverseNonequilibriumShearFlow::findSwapParticles()
+    {
+    // fill the layers with (unsorted) particles. this uses do loop for reallocation
+    bool filled = false;
+    do
+        {
+        const size_t num_lo_alloc = m_particles_lo.getNumElements();
+        const size_t num_hi_alloc = m_particles_hi.getNumElements();
+            {
+            ArrayHandle<Scalar4> h_pos(m_mpcd_pdata->getPositions(),
+                                       access_location::host,
+                                       access_mode::read);
+            ArrayHandle<Scalar4> h_vel(m_mpcd_pdata->getVelocities(),
+                                       access_location::host,
+                                       access_mode::read);
+
+            ArrayHandle<Scalar2> h_particles_lo(m_particles_lo,
+                                                access_location::host,
+                                                access_mode::overwrite);
+            ArrayHandle<Scalar2> h_particles_hi(m_particles_hi,
+                                                access_location::host,
+                                                access_mode::overwrite);
+
+            // filter particles into their slab in y-direction and record momentum in x-direction
+            m_num_lo = 0;
+            m_num_hi = 0;
+            for (unsigned int idx = 0; idx < m_mpcd_pdata->getN(); ++idx)
+                {
+                const Scalar4 vel = h_vel.data[idx];
+                const Scalar momentum = vel.x * m_mpcd_pdata->getMass();
+                const Scalar y = h_pos.data[idx].y;
+                if (m_pos_lo.x <= y && y < m_pos_lo.y
+                    && momentum > Scalar(0.0)) // lower slab, search for positive momentum
+                    {
+                    if (m_num_lo < num_lo_alloc)
+                        {
+                        h_particles_lo.data[m_num_lo]
+                            = make_scalar2(__int_as_scalar(idx), momentum);
+                        }
+                    ++m_num_lo;
+                    }
+                else if (m_pos_hi.x <= y && y < m_pos_hi.y
+                         && momentum < Scalar(0.0)) // higher slab, search for negative momentum
+                    {
+                    if (m_num_hi < num_hi_alloc)
+                        {
+                        h_particles_hi.data[m_num_hi]
+                            = make_scalar2(__int_as_scalar(idx), momentum);
+                        }
+                    ++m_num_hi;
+                    }
+                }
+            }
+        filled = true;
+
+        // reallocate if required and go again, this won't happen too much
+        if (m_num_lo > num_lo_alloc)
+            {
+            GPUArray<Scalar2> particles_lo(m_num_lo, m_exec_conf);
+            m_particles_lo.swap(particles_lo);
+            filled = false;
+            }
+        if (m_num_hi > num_hi_alloc)
+            {
+            GPUArray<Scalar2> particles_hi(m_num_hi, m_exec_conf);
+            m_particles_hi.swap(particles_hi);
+            filled = false;
+            }
+
+        } while (!filled);
+
+        // sort the arrays
+        {
+        ArrayHandle<Scalar2> h_particles_lo(m_particles_lo,
+                                            access_location::host,
+                                            access_mode::readwrite);
+        ArrayHandle<Scalar2> h_particles_hi(m_particles_hi,
+                                            access_location::host,
+                                            access_mode::readwrite);
+        ArrayHandle<unsigned int> h_tag(m_mpcd_pdata->getTags(),
+                                        access_location::host,
+                                        access_mode::read);
+
+        if (std::isinf(m_target_momentum))
+            {
+            std::sort(h_particles_lo.data,
+                      h_particles_lo.data + m_num_lo,
+                      detail::MaximumMomentum(h_tag.data));
+            std::sort(h_particles_hi.data,
+                      h_particles_hi.data + m_num_hi,
+                      detail::MinimumMomentum(h_tag.data));
+            }
+        else
+            {
+            std::sort(h_particles_lo.data,
+                      h_particles_lo.data + m_num_lo,
+                      detail::CompareMomentumToTarget(m_target_momentum, h_tag.data));
+            std::sort(h_particles_hi.data,
+                      h_particles_hi.data + m_num_hi,
+                      detail::CompareMomentumToTarget(-m_target_momentum, h_tag.data));
+            }
+        }
+    }
+
+/*!
+ * Stage particles momenta from both slabs into a queue for swapping
+ */
+void mpcd::ReverseNonequilibriumShearFlow::stageSwapParticles()
+    {
+    // determine number of pairs to swap
+    unsigned int num_lo_global = m_num_lo;
+    unsigned int num_hi_global = m_num_hi;
+#ifdef ENABLE_MPI
+    if (m_sysdef->isDomainDecomposed())
+        {
+        auto mpi_comm = m_exec_conf->getMPICommunicator();
+        MPI_Allreduce(MPI_IN_PLACE, &num_lo_global, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
+        MPI_Allreduce(MPI_IN_PLACE, &num_hi_global, 1, MPI_UNSIGNED, MPI_SUM, mpi_comm);
+        }
+#endif // ENABLE_MPI
+    const unsigned int num_pairs = std::min(m_num_swap, std::min(num_lo_global, num_hi_global));
+
+    // stage swaps into queue
+    ArrayHandle<Scalar2> h_particles_lo(m_particles_lo, access_location::host, access_mode::read);
+    ArrayHandle<Scalar2> h_particles_hi(m_particles_hi, access_location::host, access_mode::read);
+    ArrayHandle<Scalar2> h_particles_staged(m_particles_staged,
+                                            access_location::host,
+                                            access_mode::overwrite);
+    m_num_staged = 0;
+    unsigned int lo_idx = 0;
+    unsigned int hi_idx = 0;
+    for (unsigned int i = 0; i < num_pairs; ++i)
+        {
+#ifdef ENABLE_MPI
+        if (m_sysdef->isDomainDecomposed())
+            {
+            const auto mpi_comm = m_exec_conf->getMPICommunicator();
+            const int rank = m_exec_conf->getRank();
+
+            // find particle in lo slab from all ranks (p > 0)
+            MPI_Op lo_op;
+            Scalar_Int lo_swap;
+            lo_swap.i = rank;
+            if (std::isinf(m_target_momentum))
+                {
+                lo_op = MPI_MAXLOC;
+                lo_swap.s = (lo_idx < m_num_lo) ? h_particles_lo.data[lo_idx].y : Scalar(0.0);
+                }
+            else
+                {
+                lo_op = MPI_MINLOC;
+                lo_swap.s = (lo_idx < m_num_lo)
+                                ? std::fabs(h_particles_lo.data[lo_idx].y - m_target_momentum)
+                                : std::numeric_limits<Scalar>::max();
+                }
+            MPI_Allreduce(MPI_IN_PLACE, &lo_swap, 1, MPI_HOOMD_SCALAR_INT, lo_op, mpi_comm);
+
+            // find particle in hi slab to swap (p < 0)
+            Scalar_Int hi_swap;
+            hi_swap.i = rank;
+            if (hi_idx < m_num_hi)
+                {
+                hi_swap.s = (std::isinf(m_target_momentum))
+                                ? h_particles_hi.data[hi_idx].y
+                                : std::fabs(h_particles_hi.data[hi_idx].y + m_target_momentum);
+                }
+            else
+                {
+                hi_swap.s = std::numeric_limits<Scalar>::max();
+                }
+            MPI_Allreduce(MPI_IN_PLACE, &hi_swap, 1, MPI_HOOMD_SCALAR_INT, MPI_MINLOC, mpi_comm);
+
+            if (lo_swap.i == rank || hi_swap.i == rank) // at most, 2 ranks participate in the swap
+                {
+                if (lo_swap.i != hi_swap.i) // particles to swap are on different ranks, needs MPI
+                    {
+                    Scalar2 particle;
+                    unsigned int dest;
+                    if (lo_swap.i == rank)
+                        {
+                        particle = h_particles_lo.data[lo_idx++];
+                        dest = hi_swap.i;
+                        }
+                    else
+                        {
+                        particle = h_particles_hi.data[hi_idx++];
+                        dest = lo_swap.i;
+                        }
+
+                    MPI_Sendrecv_replace(&particle.y,
+                                         1,
+                                         MPI_HOOMD_SCALAR,
+                                         dest,
+                                         0,
+                                         dest,
+                                         0,
+                                         mpi_comm,
+                                         MPI_STATUS_IGNORE);
+
+                    h_particles_staged.data[m_num_staged++] = particle;
+                    }
+                else // particles are on the same rank
+                    {
+                    Scalar2 lo_particle = h_particles_lo.data[lo_idx++];
+                    Scalar2 hi_particle = h_particles_hi.data[hi_idx++];
+                    std::swap(lo_particle.y, hi_particle.y);
+                    h_particles_staged.data[m_num_staged++] = lo_particle;
+                    h_particles_staged.data[m_num_staged++] = hi_particle;
+                    }
+                }
+            }
+        else
+#endif // ENABLE_MPI
+            {
+            Scalar2 lo_particle = h_particles_lo.data[lo_idx++];
+            Scalar2 hi_particle = h_particles_hi.data[hi_idx++];
+            std::swap(lo_particle.y, hi_particle.y);
+            h_particles_staged.data[m_num_staged++] = lo_particle;
+            h_particles_staged.data[m_num_staged++] = hi_particle;
+            }
+        }
+    }
+
+/*!
+ * Apply new momenta to particles from the queue.
+ */
+void mpcd::ReverseNonequilibriumShearFlow::swapParticleMomentum()
+    {
+    ArrayHandle<Scalar4> h_vel(m_mpcd_pdata->getVelocities(),
+                               access_location::host,
+                               access_mode::readwrite);
+    ArrayHandle<Scalar2> h_particles_staged(m_particles_staged,
+                                            access_location::host,
+                                            access_mode::read);
+
+    // perform swap and sum momentum exchange
+    Scalar momentum_sum(0);
+    const Scalar mass = m_mpcd_pdata->getMass();
+    for (unsigned int i = 0; i < m_num_staged; ++i)
+        {
+        const Scalar2 pidx_mom = h_particles_staged.data[i];
+        const unsigned int pidx = __scalar_as_int(pidx_mom.x);
+        const Scalar new_momentum = pidx_mom.y;
+
+        const Scalar current_momentum = h_vel.data[pidx].x * mass;
+
+        h_vel.data[pidx].x = new_momentum / mass;
+        momentum_sum += std::fabs(new_momentum - current_momentum);
+        }
+
+#ifdef ENABLE_MPI
+    if (m_sysdef->isDomainDecomposed())
+        {
+        auto comm = m_exec_conf->getMPICommunicator();
+        MPI_Allreduce(MPI_IN_PLACE, &momentum_sum, 1, MPI_HOOMD_SCALAR, MPI_SUM, comm);
+        }
+#endif
+
+    // absolute value gives extra factor of 2, divide out when accumulating
+    m_summed_momentum_exchange += Scalar(0.5) * momentum_sum;
+    }
+
+namespace mpcd
+    {
+namespace detail
+    {
+/*!
+ * \param m Python module to export to
+ */
+void export_ReverseNonequilibriumShearFlow(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<mpcd::ReverseNonequilibriumShearFlow,
+               Updater,
+               std::shared_ptr<mpcd::ReverseNonequilibriumShearFlow>>(
+        m,
+        "ReverseNonequilibriumShearFlow")
+        .def(py::init<std::shared_ptr<SystemDefinition>,
+                      std::shared_ptr<Trigger>,
+                      unsigned int,
+                      Scalar,
+                      Scalar>())
+        .def_property("num_swaps",
+                      &mpcd::ReverseNonequilibriumShearFlow::getNumSwap,
+                      &mpcd::ReverseNonequilibriumShearFlow::setNumSwap)
+        .def_property("slab_width",
+                      &mpcd::ReverseNonequilibriumShearFlow::getSlabWidth,
+                      &mpcd::ReverseNonequilibriumShearFlow::setSlabWidth)
+        .def_property("target_momentum",
+                      &mpcd::ReverseNonequilibriumShearFlow::getTargetMomentum,
+                      &mpcd::ReverseNonequilibriumShearFlow::setTargetMomentum)
+        .def_property_readonly("summed_exchanged_momentum",
+                               &mpcd::ReverseNonequilibriumShearFlow::getSummedExchangedMomentum);
+    }
+    } // namespace detail
+    } // namespace mpcd
+    } // end namespace hoomd

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlow.h
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlow.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file ReverseNonequilibriumShearFlow.h
+ * \brief Declaration of Reverse nonequilibrium shear flow
+ */
+
+#ifndef MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_H_
+#define MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "hoomd/ParticleGroup.h"
+#include "hoomd/Updater.h"
+#include <pybind11/pybind11.h>
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+//! Reverse nonequilibrium shear flow updater
+/*!
+ * A flow is induced by swapping velocities in x direction based on particle position in
+ * y-direction.
+ */
+class PYBIND11_EXPORT ReverseNonequilibriumShearFlow : public Updater
+    {
+    public:
+    //! Constructor
+    ReverseNonequilibriumShearFlow(std::shared_ptr<SystemDefinition> sysdef,
+                                   std::shared_ptr<Trigger> trigger,
+                                   unsigned int num_swap,
+                                   Scalar slab_width,
+                                   Scalar target_momentum);
+
+    //! Destructor
+    virtual ~ReverseNonequilibriumShearFlow();
+
+    //! Apply velocity swaps
+    virtual void update(uint64_t timestep);
+
+    //! Get max number of swaps
+    Scalar getNumSwap() const
+        {
+        return m_num_swap;
+        }
+
+    //! Set the maximum number of swapped pairs
+    void setNumSwap(unsigned int num_swap);
+
+    //! Get slab width
+    Scalar getSlabWidth() const
+        {
+        return m_slab_width;
+        }
+
+    //! Set the slab width
+    void setSlabWidth(Scalar slab_width);
+
+    //! Get target momentum
+    Scalar getTargetMomentum() const
+        {
+        return m_target_momentum;
+        }
+
+    //! Set the target momentum
+    void setTargetMomentum(Scalar target_momentum);
+
+    //! Get summed exchanged momentum
+    Scalar getSummedExchangedMomentum() const
+        {
+        return m_summed_momentum_exchange;
+        }
+
+    protected:
+    std::shared_ptr<mpcd::ParticleData> m_mpcd_pdata; //!< MPCD particle data
+    unsigned int m_num_swap;                          //!< maximum number of swaps
+    Scalar m_slab_width;                              //!< width of slabs
+    Scalar m_summed_momentum_exchange;                //!< summed momentum excange between slabs
+    Scalar2 m_pos_lo;                                 //!< position of bottom slab in box
+    Scalar2 m_pos_hi;                                 //!< position of top slab in box
+    unsigned int m_num_lo;                            //!< number of particles in bottom slab
+    GPUArray<Scalar2> m_particles_lo; //!< List of all particles (indices,momentum) in bottom slab
+                                      //!< sorted by momentum closest to +m_target_momentum
+    unsigned int m_num_hi;            //!< number of particles in top slab
+    GPUArray<Scalar2> m_particles_hi; //!< List of all particles (indices,momentum) in top slab
+                                      //!< sorted by momentum closest to -m_target_momentum
+    unsigned int m_num_staged;        //!< number of particles staged for swapping
+    GPUArray<Scalar2> m_particles_staged; //!< List of all particles staged for swapping
+    Scalar m_target_momentum;             //!< target momentum for particles in the slabs
+
+    //! Find candidate particles for swapping in the slabs
+    virtual void findSwapParticles();
+
+    //! Stage particle momentum for swapping
+    void stageSwapParticles();
+
+    //! Swaps momentum between the slabs
+    virtual void swapParticleMomentum();
+
+    private:
+    bool m_update_slabs; //!< If true, update the slab positions
+
+    //! Request to check box on next update
+    void requestUpdateSlabs()
+        {
+        m_update_slabs = true;
+        }
+
+    //! Sets the slab positions in the box and validates them
+    void setSlabs();
+    };
+
+    } // end namespace mpcd
+    } // end namespace hoomd
+#endif // MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_H_

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cc
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cc
@@ -1,0 +1,207 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ReverseNonequilibriumShearFlowGPU.h
+ * \brief Definition of mpcd::ReverseNonequilibriumShearFlowGPU
+ */
+
+#include "ReverseNonequilibriumShearFlowGPU.cuh"
+#include "ReverseNonequilibriumShearFlowGPU.h"
+#include "ReverseNonequilibriumShearFlowUtilities.h"
+
+namespace hoomd
+    {
+
+mpcd::ReverseNonequilibriumShearFlowGPU::ReverseNonequilibriumShearFlowGPU(
+    std::shared_ptr<SystemDefinition> sysdef,
+    std::shared_ptr<Trigger> trigger,
+    unsigned int num_swap,
+    Scalar slab_width,
+    Scalar target_momentum)
+    : mpcd::ReverseNonequilibriumShearFlow(sysdef, trigger, num_swap, slab_width, target_momentum),
+      m_num_lo_hi(2, m_exec_conf), m_momentum_sum(m_exec_conf)
+    {
+    m_tuner_filter.reset(new Autotuner<1>({AutotunerBase::makeBlockSizeRange(m_exec_conf)},
+                                          m_exec_conf,
+                                          "mpcd_rnes_filter"));
+    m_tuner_swap.reset(new Autotuner<1>({AutotunerBase::makeBlockSizeRange(m_exec_conf)},
+                                        m_exec_conf,
+                                        "mpcd_rnes_swap"));
+    m_autotuners.insert(m_autotuners.end(), {m_tuner_filter, m_tuner_swap});
+    }
+
+void mpcd::ReverseNonequilibriumShearFlowGPU::findSwapParticles()
+    {
+    // fill the layers with (unsorted) particles. this uses do loop for reallocation
+    bool filled = false;
+    do
+        {
+        const unsigned int num_lo_alloc
+            = static_cast<unsigned int>(m_particles_lo.getNumElements());
+        const unsigned int num_hi_alloc
+            = static_cast<unsigned int>(m_particles_hi.getNumElements());
+            // filter particles into their slab in y-direction and record momentum in x-direction
+            {
+            ArrayHandle<Scalar4> d_pos(m_mpcd_pdata->getPositions(),
+                                       access_location::device,
+                                       access_mode::read);
+            ArrayHandle<Scalar4> d_vel(m_mpcd_pdata->getVelocities(),
+                                       access_location::device,
+                                       access_mode::read);
+
+            ArrayHandle<Scalar2> d_particles_lo(m_particles_lo,
+                                                access_location::device,
+                                                access_mode::overwrite);
+            ArrayHandle<Scalar2> d_particles_hi(m_particles_hi,
+                                                access_location::device,
+                                                access_mode::overwrite);
+            ArrayHandle<unsigned int> d_num_lo_hi(m_num_lo_hi,
+                                                  access_location::device,
+                                                  access_mode::overwrite);
+
+            m_tuner_filter->begin();
+            mpcd::gpu::rnes_filter_particles(d_particles_lo.data,
+                                             d_particles_hi.data,
+                                             d_num_lo_hi.data,
+                                             d_pos.data,
+                                             d_vel.data,
+                                             m_mpcd_pdata->getMass(),
+                                             m_pos_lo,
+                                             m_pos_hi,
+                                             num_lo_alloc,
+                                             num_hi_alloc,
+                                             m_mpcd_pdata->getN(),
+                                             m_tuner_filter->getParam()[0]);
+            if (m_exec_conf->isCUDAErrorCheckingEnabled())
+                CHECK_CUDA_ERROR();
+            m_tuner_filter->end();
+            }
+
+            // read number in each slab
+            {
+            ArrayHandle<unsigned int> h_num_lo_hi(m_num_lo_hi,
+                                                  access_location::host,
+                                                  access_mode::read);
+            m_num_lo = h_num_lo_hi.data[0];
+            m_num_hi = h_num_lo_hi.data[1];
+            }
+
+        // reallocate if required and go again, this won't happen too much
+        filled = true;
+        if (m_num_lo > num_lo_alloc)
+            {
+            GPUArray<Scalar2> particles_lo(m_num_lo, m_exec_conf);
+            m_particles_lo.swap(particles_lo);
+            filled = false;
+            }
+        if (m_num_hi > num_hi_alloc)
+            {
+            GPUArray<Scalar2> particles_hi(m_num_hi, m_exec_conf);
+            m_particles_hi.swap(particles_hi);
+            filled = false;
+            }
+        } while (!filled);
+    }
+
+void mpcd::ReverseNonequilibriumShearFlowGPU::sortOutSwapParticles()
+    {
+    ArrayHandle<Scalar2> d_particles_lo(m_particles_lo,
+                                        access_location::device,
+                                        access_mode::readwrite);
+    ArrayHandle<Scalar2> d_particles_hi(m_particles_hi,
+                                        access_location::device,
+                                        access_mode::readwrite);
+    ArrayHandle<unsigned int> d_tag(m_mpcd_pdata->getTags(),
+                                    access_location::device,
+                                    access_mode::read);
+
+    if (std::isinf(m_target_momentum))
+        {
+        mpcd::gpu::rnes_sort(d_particles_lo.data, m_num_lo, detail::MaximumMomentum(d_tag.data));
+        mpcd::gpu::rnes_sort(d_particles_hi.data, m_num_hi, detail::MinimumMomentum(d_tag.data));
+        }
+    else
+        {
+        mpcd::gpu::rnes_sort(d_particles_lo.data,
+                             m_num_lo,
+                             detail::CompareMomentumToTarget(m_target_momentum, d_tag.data));
+        mpcd::gpu::rnes_sort(d_particles_hi.data,
+                             m_num_hi,
+                             detail::CompareMomentumToTarget(-m_target_momentum, d_tag.data));
+        }
+
+    // copy only the top particles to the host memory
+    const unsigned int num_top_lo = std::min(m_num_swap, m_num_lo);
+    m_top_particles_lo.resize(num_top_lo);
+    mpcd::gpu::rnes_copy_top_particles(m_top_particles_lo.data(), d_particles_lo.data, num_top_lo);
+    if (m_exec_conf->isCUDAErrorCheckingEnabled())
+        CHECK_CUDA_ERROR();
+
+    const unsigned int num_top_hi = std::min(m_num_swap, m_num_hi);
+    m_top_particles_hi.resize(num_top_hi);
+    mpcd::gpu::rnes_copy_top_particles(m_top_particles_hi.data(), d_particles_hi.data, num_top_hi);
+    if (m_exec_conf->isCUDAErrorCheckingEnabled())
+        CHECK_CUDA_ERROR();
+    }
+
+void mpcd::ReverseNonequilibriumShearFlowGPU::swapParticleMomentum()
+    {
+    ArrayHandle<Scalar4> d_vel(m_mpcd_pdata->getVelocities(),
+                               access_location::device,
+                               access_mode::readwrite);
+    ArrayHandle<Scalar2> d_particles_staged(m_particles_staged,
+                                            access_location::device,
+                                            access_mode::read);
+
+    // perform swap
+    m_momentum_sum.resetFlags(0);
+    m_tuner_swap->begin();
+    mpcd::gpu::rnes_swap_particles(d_vel.data,
+                                   m_momentum_sum.getDeviceFlags(),
+                                   d_particles_staged.data,
+                                   m_mpcd_pdata->getMass(),
+                                   m_num_staged,
+                                   m_tuner_swap->getParam()[0]);
+    if (m_exec_conf->isCUDAErrorCheckingEnabled())
+        CHECK_CUDA_ERROR();
+    m_tuner_swap->end();
+
+    // sum momentum exchange from this swap
+    Scalar momentum_sum = m_momentum_sum.readFlags();
+#ifdef ENABLE_MPI
+    if (m_sysdef->isDomainDecomposed())
+        {
+        auto comm = m_exec_conf->getMPICommunicator();
+        MPI_Allreduce(MPI_IN_PLACE, &momentum_sum, 1, MPI_HOOMD_SCALAR, MPI_SUM, comm);
+        }
+#endif
+
+    // absolute value gives extra factor of 2, divide out when accumulating
+    m_summed_momentum_exchange += Scalar(0.5) * momentum_sum;
+    }
+
+namespace mpcd
+    {
+namespace detail
+    {
+/*!
+ * \param m Python module to export to
+ */
+void export_ReverseNonequilibriumShearFlowGPU(pybind11::module& m)
+    {
+    pybind11::class_<mpcd::ReverseNonequilibriumShearFlowGPU,
+                     mpcd::ReverseNonequilibriumShearFlow,
+                     std::shared_ptr<mpcd::ReverseNonequilibriumShearFlowGPU>>(
+        m,
+        "ReverseNonequilibriumShearFlowGPU")
+        .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            std::shared_ptr<Trigger>,
+                            unsigned int,
+                            Scalar,
+                            Scalar>());
+    }
+    } // namespace detail
+    } // namespace mpcd
+
+    } // end namespace hoomd

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cu
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cu
@@ -1,0 +1,173 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ReverseNonequilibriumShearFlowGPU.cu
+ * \brief Defines GPU functions and kernels used by mpcd::ReverseNonequilibriumShearFlowGPU
+ */
+
+#include "ReverseNonequilibriumShearFlowGPU.cuh"
+#include "ReverseNonequilibriumShearFlowUtilities.h"
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+namespace gpu
+    {
+namespace kernel
+    {
+
+__global__ void rnes_filter_particles(Scalar2* d_particles_lo,
+                                      Scalar2* d_particles_hi,
+                                      unsigned int* d_num_lo_hi,
+                                      const Scalar4* d_pos,
+                                      const Scalar4* d_vel,
+                                      const Scalar mass,
+                                      const Scalar2 pos_lo,
+                                      const Scalar2 pos_hi,
+                                      const unsigned int num_lo_alloc,
+                                      const unsigned int num_hi_alloc,
+                                      const unsigned int N)
+    {
+    // one thread per particle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+        return;
+
+    const Scalar4 vel = d_vel[idx];
+    const Scalar momentum = vel.x * mass;
+    const Scalar y = d_pos[idx].y;
+
+    if (pos_lo.x <= y && y < pos_lo.y
+        && momentum > Scalar(0.0)) // lower slab, search for positive momentum
+        {
+        const unsigned int num_lo = atomicInc(d_num_lo_hi, 0xffffffff);
+        if (num_lo < num_lo_alloc)
+            {
+            d_particles_lo[num_lo] = make_scalar2(__int_as_scalar(idx), momentum);
+            }
+        }
+    else if (pos_hi.x <= y && y < pos_hi.y
+             && momentum < Scalar(0.0)) // higher slab, search for negative momentum
+        {
+        const unsigned int num_hi = atomicInc(d_num_lo_hi + 1, 0xffffffff);
+        if (num_hi < num_hi_alloc)
+            {
+            d_particles_hi[num_hi] = make_scalar2(__int_as_scalar(idx), momentum);
+            }
+        }
+    }
+
+__global__ void rnes_swap_particles(Scalar4* d_vel,
+                                    Scalar* d_momentum_sum,
+                                    const Scalar2* d_particles_staged,
+                                    const Scalar mass,
+                                    const unsigned int num_staged)
+    {
+    // one thread per particle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= num_staged)
+        return;
+
+    const Scalar2 pidx_mom = d_particles_staged[idx];
+    const unsigned int pidx = __scalar_as_int(pidx_mom.x);
+    const Scalar new_momentum = pidx_mom.y;
+
+    const Scalar current_momentum = d_vel[pidx].x * mass;
+
+    d_vel[pidx].x = new_momentum / mass;
+    atomicAdd(d_momentum_sum, std::fabs(new_momentum - current_momentum));
+    }
+
+    } // end namespace kernel
+
+cudaError_t rnes_filter_particles(Scalar2* d_particles_lo,
+                                  Scalar2* d_particles_hi,
+                                  unsigned int* d_num_lo_hi,
+                                  const Scalar4* d_pos,
+                                  const Scalar4* d_vel,
+                                  const Scalar mass,
+                                  const Scalar2& pos_lo,
+                                  const Scalar2& pos_hi,
+                                  const unsigned int num_lo_alloc,
+                                  const unsigned int num_hi_alloc,
+                                  const unsigned int N,
+                                  const unsigned int block_size)
+    {
+    // zero counts in each bin
+    cudaError_t error = cudaMemset(d_num_lo_hi, 0, 2 * sizeof(unsigned int));
+    if (error != cudaSuccess)
+        return error;
+
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::rnes_filter_particles);
+    max_block_size = attr.maxThreadsPerBlock;
+
+    unsigned int run_block_size = min(block_size, max_block_size);
+
+    dim3 grid(N / run_block_size + 1);
+    mpcd::gpu::kernel::rnes_filter_particles<<<grid, run_block_size>>>(d_particles_lo,
+                                                                       d_particles_hi,
+                                                                       d_num_lo_hi,
+                                                                       d_pos,
+                                                                       d_vel,
+                                                                       mass,
+                                                                       pos_lo,
+                                                                       pos_hi,
+                                                                       num_lo_alloc,
+                                                                       num_hi_alloc,
+                                                                       N);
+
+    return cudaSuccess;
+    }
+
+template void rnes_sort<mpcd::detail::MinimumMomentum>(Scalar2*,
+                                                       const unsigned int,
+                                                       const mpcd::detail::MinimumMomentum&);
+template void rnes_sort<mpcd::detail::MaximumMomentum>(Scalar2*,
+                                                       const unsigned int,
+                                                       const mpcd::detail::MaximumMomentum&);
+template void
+rnes_sort<mpcd::detail::CompareMomentumToTarget>(Scalar2*,
+                                                 const unsigned int,
+                                                 const mpcd::detail::CompareMomentumToTarget&);
+
+cudaError_t rnes_copy_top_particles(Scalar2* h_top_particles,
+                                    const Scalar2* d_particles,
+                                    const unsigned int num_top)
+    {
+    return cudaMemcpy(h_top_particles,
+                      d_particles,
+                      num_top * sizeof(Scalar2),
+                      cudaMemcpyDeviceToHost);
+    }
+
+cudaError_t rnes_swap_particles(Scalar4* d_vel,
+                                Scalar* d_momentum_sum,
+                                const Scalar2* d_particles_staged,
+                                const Scalar mass,
+                                const unsigned int num_staged,
+                                const unsigned int block_size)
+    {
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::rnes_swap_particles);
+    max_block_size = attr.maxThreadsPerBlock;
+
+    unsigned int run_block_size = min(block_size, max_block_size);
+
+    dim3 grid(num_staged / run_block_size + 1);
+    mpcd::gpu::kernel::rnes_swap_particles<<<grid, run_block_size>>>(d_vel,
+                                                                     d_momentum_sum,
+                                                                     d_particles_staged,
+                                                                     mass,
+                                                                     num_staged);
+
+    return cudaSuccess;
+    }
+
+    } // end namespace gpu
+    } // end namespace mpcd
+    } // end namespace hoomd

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
@@ -10,12 +10,10 @@
  */
 
 #include <cuda_runtime.h>
-#ifdef __HIPCC__
-#include <thrust/execution_policy.h>
-#include <thrust/sort.h>
-#endif // __HIPCC__
 
 #include "hoomd/HOOMDMath.h"
+
+#include "ReverseNonequilibriumShearFlowUtilities.h"
 
 namespace hoomd
     {
@@ -38,7 +36,11 @@ cudaError_t rnes_filter_particles(Scalar2* d_particles_lo,
                                   const unsigned int N,
                                   const unsigned int block_size);
 
-template<class T> void rnes_sort(Scalar2* d_particles, const unsigned int N, const T& comp);
+void rnes_sort(Scalar2* d_particles, const unsigned int N, const detail::MinimumMomentum& comp);
+void rnes_sort(Scalar2* d_particles, const unsigned int N, const detail::MaximumMomentum& comp);
+void rnes_sort(Scalar2* d_particles,
+               const unsigned int N,
+               const detail::CompareMomentumToTarget& comp);
 
 cudaError_t rnes_copy_top_particles(Scalar2* h_top_particles,
                                     const Scalar2* d_particles,
@@ -52,10 +54,7 @@ cudaError_t rnes_swap_particles(Scalar4* d_vel,
                                 const unsigned int block_size);
 
 #ifdef __HIPCC__
-template<class T> void rnes_sort(Scalar2* d_particles, const unsigned int N, const T& comp)
-    {
-    thrust::sort(thrust::device, d_particles, d_particles + N, comp);
-    }
+
 #endif
 
     } // end namespace gpu

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
@@ -10,8 +10,10 @@
  */
 
 #include <cuda_runtime.h>
+#ifdef __HIPCC__
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
+#endif // __HIPCC__
 
 #include "hoomd/HOOMDMath.h"
 

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.cuh
@@ -1,0 +1,62 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+#ifndef MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_CUH_
+#define MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_CUH_
+
+/*!
+ * \file mpcd/ReverseNonequilibriumShearFlowGPU.cuh
+ * \brief Declaration of CUDA kernels for mpcd::ReverseNonequilibriumShearFlowGPU
+ */
+
+#include <cuda_runtime.h>
+#include <thrust/execution_policy.h>
+#include <thrust/sort.h>
+
+#include "hoomd/HOOMDMath.h"
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+namespace gpu
+    {
+
+//! Filter particles into slabs
+cudaError_t rnes_filter_particles(Scalar2* d_particles_lo,
+                                  Scalar2* d_particles_hi,
+                                  unsigned int* d_num_lo_hi,
+                                  const Scalar4* d_pos,
+                                  const Scalar4* d_vel,
+                                  const Scalar mass,
+                                  const Scalar2& pos_lo,
+                                  const Scalar2& pos_hi,
+                                  const unsigned int num_lo_alloc,
+                                  const unsigned int num_hi_alloc,
+                                  const unsigned int N,
+                                  const unsigned int block_size);
+
+template<class T> void rnes_sort(Scalar2* d_particles, const unsigned int N, const T& comp);
+
+cudaError_t rnes_copy_top_particles(Scalar2* h_top_particles,
+                                    const Scalar2* d_particles,
+                                    const unsigned int num_top);
+
+cudaError_t rnes_swap_particles(Scalar4* d_vel,
+                                Scalar* d_momentum_sum,
+                                const Scalar2* d_particles_staged,
+                                const Scalar mass,
+                                const unsigned int num_staged,
+                                const unsigned int block_size);
+
+#ifdef __HIPCC__
+template<class T> void rnes_sort(Scalar2* d_particles, const unsigned int N, const T& comp)
+    {
+    thrust::sort(thrust::device, d_particles, d_particles + N, comp);
+    }
+#endif
+
+    } // end namespace gpu
+    } // end namespace mpcd
+    } // end namespace hoomd
+#endif // MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_CUH_

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.h
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowGPU.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ReverseNonequilibriumShearFlowGPU.h
+ * \brief Declaration of reverse nonequilibrium shear flow updater on the GPU.
+ */
+
+#ifndef MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_H_
+#define MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_H_
+
+#ifdef __HIPCC__
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "ReverseNonequilibriumShearFlow.h"
+#include "hoomd/Autotuner.h"
+#include "hoomd/GPUFlags.h"
+#include <pybind11/pybind11.h>
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+//! Reverse nonequilibrium shear flow updater on GPU
+class PYBIND11_EXPORT ReverseNonequilibriumShearFlowGPU : public ReverseNonequilibriumShearFlow
+    {
+    public:
+    //! Constructor
+    ReverseNonequilibriumShearFlowGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                      std::shared_ptr<Trigger> trigger,
+                                      unsigned int num_swap,
+                                      Scalar slab_width,
+                                      Scalar target_momentum);
+
+    protected:
+    //! Find candidate particles for swapping
+    void findSwapParticles() override;
+
+    //! Sort and copy only the top candidates for swapping
+    void sortOutSwapParticles() override;
+
+    //! Swap particle momenta
+    void swapParticleMomentum() override;
+
+    private:
+    GPUArray<unsigned int> m_num_lo_hi;
+    GPUFlags<Scalar> m_momentum_sum;
+    std::shared_ptr<hoomd::Autotuner<1>> m_tuner_filter; //!< Autotuner for filtering particles
+    std::shared_ptr<hoomd::Autotuner<1>> m_tuner_swap;   //!< Autotuner for swapping particles
+    };
+    } // end namespace mpcd
+    } // end namespace hoomd
+#endif // MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_GPU_H_

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowUtilities.h
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowUtilities.h
@@ -11,6 +11,12 @@
 
 #include "hoomd/HOOMDMath.h"
 
+#ifdef __HIPCC__
+#define HOSTDEVICE __host__ __device__ inline
+#else
+#define HOSTDEVICE inline __attribute__((always_inline))
+#endif // __HIPCC__
+
 namespace hoomd
     {
 namespace mpcd
@@ -21,12 +27,12 @@ namespace detail
 class CompareMomentumToTarget
     {
     public:
-    CompareMomentumToTarget(Scalar target_momentum, const unsigned int* tags_)
+    HOSTDEVICE CompareMomentumToTarget(Scalar target_momentum, const unsigned int* tags_)
         : p(target_momentum), tags(tags_)
         {
         }
 
-    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+    HOSTDEVICE bool operator()(const Scalar2& in0, const Scalar2& in1) const
         {
         const Scalar dp0 = std::fabs(in0.y - p);
         const Scalar dp1 = std::fabs(in1.y - p);
@@ -55,9 +61,9 @@ class CompareMomentumToTarget
 class MaximumMomentum
     {
     public:
-    MaximumMomentum(const unsigned int* tags_) : tags(tags_) { }
+    HOSTDEVICE MaximumMomentum(const unsigned int* tags_) : tags(tags_) { }
 
-    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+    HOSTDEVICE bool operator()(const Scalar2& in0, const Scalar2& in1) const
         {
         const Scalar p0 = in0.y;
         const Scalar p1 = in1.y;
@@ -85,9 +91,9 @@ class MaximumMomentum
 class MinimumMomentum
     {
     public:
-    MinimumMomentum(const unsigned int* tags_) : tags(tags_) { }
+    HOSTDEVICE MinimumMomentum(const unsigned int* tags_) : tags(tags_) { }
 
-    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+    HOSTDEVICE bool operator()(const Scalar2& in0, const Scalar2& in1) const
         {
         const Scalar p0 = in0.y;
         const Scalar p1 = in1.y;
@@ -115,5 +121,7 @@ class MinimumMomentum
     } // end namespace detail
     } // end namespace mpcd
     } // end namespace hoomd
+
+#undef HOSTDEVICE
 
 #endif // MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_UTILITIES_H_

--- a/hoomd/mpcd/ReverseNonequilibriumShearFlowUtilities.h
+++ b/hoomd/mpcd/ReverseNonequilibriumShearFlowUtilities.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file ReverseNonequilibriumShearFlowUtilities.h
+ * \brief Helper functions for Reverse nonequilibrium shear flow
+ */
+
+#ifndef MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_UTILITIES_H_
+#define MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_UTILITIES_H_
+
+#include "hoomd/HOOMDMath.h"
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+namespace detail
+    {
+
+class CompareMomentumToTarget
+    {
+    public:
+    CompareMomentumToTarget(Scalar target_momentum, const unsigned int* tags_)
+        : p(target_momentum), tags(tags_)
+        {
+        }
+
+    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+        {
+        const Scalar dp0 = std::fabs(in0.y - p);
+        const Scalar dp1 = std::fabs(in1.y - p);
+        if (dp0 < dp1)
+            {
+            // 0 is closer to target than 1
+            return true;
+            }
+        else if (dp0 > dp1)
+            {
+            // 0 is farther from target than 1
+            return false;
+            }
+        else
+            {
+            // both are equal distant, break tie using lower tag
+            return tags[__scalar_as_int(in0.x)] < tags[__scalar_as_int(in1.x)];
+            }
+        }
+
+    private:
+    const Scalar p;                 //!< Momentum target
+    const unsigned int* const tags; //!< Tag array
+    };
+
+class MaximumMomentum
+    {
+    public:
+    MaximumMomentum(const unsigned int* tags_) : tags(tags_) { }
+
+    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+        {
+        const Scalar p0 = in0.y;
+        const Scalar p1 = in1.y;
+        if (p0 > p1)
+            {
+            // particle 0 has higher momemtum than 1 so should be selected first
+            return true;
+            }
+        else if (p0 < p1)
+            {
+            // particle 0 has lower momentum than 1
+            return false;
+            }
+        else
+            {
+            // both are equal distant, break tie using lower tag
+            return tags[__scalar_as_int(in0.x)] < tags[__scalar_as_int(in1.x)];
+            }
+        }
+
+    private:
+    const unsigned int* const tags; //!< Tag array
+    };
+
+class MinimumMomentum
+    {
+    public:
+    MinimumMomentum(const unsigned int* tags_) : tags(tags_) { }
+
+    bool operator()(const Scalar2& in0, const Scalar2& in1) const
+        {
+        const Scalar p0 = in0.y;
+        const Scalar p1 = in1.y;
+        if (p0 < p1)
+            {
+            // particle 0 is lower in momemtum than 1 so should be selected first
+            return true;
+            }
+        else if (p0 > p1)
+            {
+            // partilce 0 has higher momentum than 1
+            return false;
+            }
+        else
+            {
+            // both are equal distant, break tie using lower tag
+            return tags[__scalar_as_int(in0.x)] < tags[__scalar_as_int(in1.x)];
+            }
+        }
+
+    private:
+    const unsigned int* const tags; //!< Tag array
+    };
+
+    } // end namespace detail
+    } // end namespace mpcd
+    } // end namespace hoomd
+
+#endif // MPCD_REVERSE_NONEQUILIBRIUM_SHEAR_FLOW_UTILITIES_H_

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -67,6 +67,7 @@ from hoomd.mpcd.integrate import Integrator
 from hoomd.mpcd import methods
 from hoomd.mpcd import stream
 from hoomd.mpcd import tune
+from hoomd.mpcd import update
 
 __all__ = [
     "Integrator",
@@ -77,4 +78,5 @@ __all__ = [
     "methods",
     "stream",
     "tune",
+    "update",
 ]

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -42,6 +42,7 @@ void export_ParallelPlateGeometry(pybind11::module&);
 void export_ParallelPlateGeometryFiller(pybind11::module&);
 void export_PlanarPoreGeometry(pybind11::module&);
 void export_PlanarPoreGeometryFiller(pybind11::module&);
+void export_ReverseNonequilibriumShearFlow(pybind11::module&);
 void export_Sorter(pybind11::module&);
 void export_SphereGeometry(pybind11::module&);
 void export_SphereGeometryFiller(pybind11::module&);
@@ -218,6 +219,7 @@ PYBIND11_MODULE(_mpcd, m)
     export_ParallelPlateGeometryFiller(m);
     export_PlanarPoreGeometry(m);
     export_PlanarPoreGeometryFiller(m);
+    export_ReverseNonequilibriumShearFlow(m);
     export_Sorter(m);
     export_SphereGeometry(m);
     export_SphereGeometryFiller(m);

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -62,6 +62,7 @@ void export_CosineChannelGeometryFillerGPU(pybind11::module&);
 void export_CosineExpansionContractionGeometryFillerGPU(pybind11::module&);
 void export_ParallelPlateGeometryFillerGPU(pybind11::module&);
 void export_PlanarPoreGeometryFillerGPU(pybind11::module&);
+void export_ReverseNonequilibriumShearFlowGPU(pybind11::module&);
 void export_SorterGPU(pybind11::module&);
 void export_SphereGeometryFillerGPU(pybind11::module&);
 void export_SRDCollisionMethodGPU(pybind11::module&);
@@ -237,6 +238,7 @@ PYBIND11_MODULE(_mpcd, m)
     export_CosineExpansionContractionGeometryFillerGPU(m);
     export_ParallelPlateGeometryFillerGPU(m);
     export_PlanarPoreGeometryFillerGPU(m);
+    export_ReverseNonequilibriumShearFlowGPU(m);
     export_SorterGPU(m);
     export_SphereGeometryFillerGPU(m);
     export_SRDCollisionMethodGPU(m);

--- a/hoomd/mpcd/pytest/CMakeLists.txt
+++ b/hoomd/mpcd/pytest/CMakeLists.txt
@@ -9,6 +9,7 @@ set(files __init__.py
     test_snapshot.py
     test_stream.py
     test_tune.py
+    test_update.py
     )
 
 install(FILES ${files}

--- a/hoomd/mpcd/pytest/test_update.py
+++ b/hoomd/mpcd/pytest/test_update.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+import pytest
+import hoomd
+import numpy as np
+
+from hoomd.conftest import pickling_check
+from hoomd.logging import LoggerCategories
+from hoomd.conftest import logging_check
+
+
+@pytest.fixture
+def snap():
+    snap = hoomd.Snapshot()
+    if snap.communicator.rank == 0:
+        snap.configuration.box = [20, 20, 20, 0, 0, 0]
+        snap.particles.N = 0
+        snap.particles.types = ["A"]
+        snap.mpcd.types = ["A"]
+        snap.mpcd.mass = 1.0
+    return snap
+
+
+@pytest.fixture
+def flow():
+    flow = hoomd.mpcd.update.ReverseNonequilibriumShearFlow(
+        trigger=1, num_swaps=1, slab_width=1.0
+    )
+    return flow
+
+
+decompositions = [None]
+if hoomd.communicator.Communicator().num_ranks == 2:
+    decompositions += [(1, 2, 1), (2, 1, 1)]
+
+
+class TestReverseNonequilibriumShearFlow:
+    def test_create(self, simulation_factory, snap, flow):
+        # before attachment
+        flow.num_swaps = 5  # changing the value before attachment
+        flow.target_momentum = 2.5  # changing the value before attachment
+        trigger = hoomd.trigger.Periodic(1)
+        flow.trigger = trigger
+
+        assert flow.trigger is trigger
+        assert flow.slab_width == 1.0
+
+        with pytest.raises(hoomd.error.DataAccessError):
+            assert flow.summed_exchanged_momentum == 0.0
+
+        sim = simulation_factory(snap)
+        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.09)
+        sim.operations.updaters.append(flow)
+        sim.run(0)
+
+        # after attachment
+        assert flow.num_swaps == 5
+        assert flow.target_momentum == 2.5
+        assert flow.trigger is trigger
+        assert flow.slab_width == 1.0
+
+        assert flow.summed_exchanged_momentum == 0.0
+
+    def test_pickling(self, simulation_factory, snap, flow):
+        pickling_check(flow)
+
+        flow.trigger = hoomd.trigger.Periodic(1)
+        flow.num_swaps = 5
+        pickling_check(flow)
+
+        sim = simulation_factory(snap)
+        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.09)
+        sim.operations.updaters.append(flow)
+        sim.run(0)
+        pickling_check(flow)
+
+    # particle locations in/out of the slabs; and at the boundaries
+    @pytest.mark.parametrize("decomposition", decompositions)
+    @pytest.mark.parametrize(
+        "v0, v1, y0, y1, swap",
+        [
+            [-2, 2, 0.5, -9.5, True],
+            [2, -2, 0.5, -9.5, False],
+            [-2, -2, 0.5, -9.5, False],
+            [2, 2, 0.5, -9.5, False],
+            [-2, 2, 0.5, -7.0, False],
+            [-2, 2, 5.0, -9.5, False],
+            [-2, 2, 5.0, -7.0, False],
+            [-2, 2, 0.0, -10.0, True],
+            [-2, 2, 0.0, -9.0, False],
+            [-2, 2, 1.0, -9.0, False],
+            [-2, 2, 1.0, -10.0, False],
+        ],
+    )
+    def test_particle_swapping(
+        self, simulation_factory, snap, flow, v0, v1, y0, y1, swap, decomposition
+    ):
+        if snap.communicator.rank == 0:
+            snap.mpcd.N = 2
+            snap.mpcd.position[0] = [1.0, y0, 2.0]
+            snap.mpcd.position[1] = [1.0, y1, 2.0]
+            snap.mpcd.velocity[0] = [v0, 4.0, 5.0]
+            snap.mpcd.velocity[1] = [v1, 1.0, 3.0]
+
+        flow.target_momentum = 2.0
+        sim = simulation_factory(snap, domain_decomposition=decomposition)
+        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.09)
+        sim.operations.updaters.append(flow)
+        sim.run(1)
+
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            assert np.allclose(snap.mpcd.velocity[0], [v1 if swap else v0, 4.0, 5.0])
+            assert np.allclose(snap.mpcd.velocity[1], [v0 if swap else v1, 1.0, 3.0])
+
+        sim.run(1)
+
+        # confirm that no further swaps happen after the previous run
+        snapshot = sim.state.get_snapshot()
+        if snapshot.communicator.rank == 0:
+            assert np.allclose(snapshot.mpcd.velocity[0], snap.mpcd.velocity[0])
+            assert np.allclose(snapshot.mpcd.velocity[1], snap.mpcd.velocity[1])
+
+    def test_swapping_at_different_timesteps(self, simulation_factory, snap, flow):
+        flow.target_momentum = 2.0
+        # set initial positions and velocities
+        if snap.communicator.rank == 0:
+            snap.mpcd.N = 4
+            snap.mpcd.position[0] = [1.0, 0.0, 2.0]
+            snap.mpcd.position[1] = [2.0, 0.3, 1.0]
+            snap.mpcd.position[2] = [1.0, -9.7, 3.0]
+            snap.mpcd.position[3] = [3.0, -10.0, 1.0]
+
+            snap.mpcd.velocity[0] = [-1.0, 4.0, 5.0]
+            snap.mpcd.velocity[1] = [-9.0, 1.0, 3.0]
+            snap.mpcd.velocity[2] = [1.0, -2.0, 4.0]
+            snap.mpcd.velocity[3] = [5.0, -4.0, -1.0]
+
+        # set up simulation
+        flow.num_swaps = 1
+        sim = simulation_factory(snap)
+        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.09)
+        sim.operations.updaters.append(flow)
+        sim.run(1)
+
+        assert flow.summed_exchanged_momentum == 2.0
+
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            # check that swap only happens between particle ids 0,2
+            assert np.allclose(snap.mpcd.velocity[0], [1.0, 4.0, 5.0])
+            assert np.allclose(snap.mpcd.velocity[1], [-9.0, 1.0, 3.0])
+            assert np.allclose(snap.mpcd.velocity[2], [-1.0, -2.0, 4.0])
+            assert np.allclose(snap.mpcd.velocity[3], [5.0, -4.0, -1.0])
+
+        sim.run(1)
+
+        assert flow.summed_exchanged_momentum == 2.0 + 14.0
+
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            # check that swapping is now between particle ids 1,3
+            assert np.allclose(snap.mpcd.velocity[0], [1.0, 4.0, 5.0])
+            assert np.allclose(snap.mpcd.velocity[1], [5.0, 1.0, 3.0])
+            assert np.allclose(snap.mpcd.velocity[2], [-1.0, -2.0, 4.0])
+            assert np.allclose(snap.mpcd.velocity[3], [-9.0, -4.0, -1.0])
+
+    def test_default_target_momentum(self, simulation_factory, snap, flow):
+        if snap.communicator.rank == 0:
+            snap.mpcd.N = 4
+            # set initial positions and velocities
+            snap.mpcd.position[0] = [1.0, 0.5, 2.0]
+            snap.mpcd.position[1] = [2.0, 0.3, 1.0]
+            snap.mpcd.position[2] = [1.0, -9.7, 3.0]
+            snap.mpcd.position[3] = [3.0, -9.2, 1.0]
+
+            snap.mpcd.velocity[0] = [-9.0, 4.0, 5.0]
+            snap.mpcd.velocity[1] = [-1.0, 1.0, 3.0]
+            snap.mpcd.velocity[2] = [1.0, -2.0, 4.0]
+            snap.mpcd.velocity[3] = [3.0, -4.0, -1.0]
+
+        # set up simulation
+        sim = simulation_factory(snap)
+        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.09)
+        sim.operations.updaters.append(flow)
+        sim.run(1)
+
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            # check that swap only happens between fastest and slowest particles
+            assert np.allclose(snap.mpcd.velocity[0], [3.0, 4.0, 5.0])
+            assert np.allclose(snap.mpcd.velocity[1], [-1.0, 1.0, 3.0])
+            assert np.allclose(snap.mpcd.velocity[2], [1.0, -2.0, 4.0])
+            assert np.allclose(snap.mpcd.velocity[3], [-9.0, -4.0, -1.0])
+
+    def test_logging(self):
+        logging_check(
+            hoomd.mpcd.update.ReverseNonequilibriumShearFlow,
+            ("mpcd", "update"),
+            {
+                "summed_exchanged_momentum": {
+                    "category": LoggerCategories.scalar,
+                    "default": True,
+                }
+            },
+        )

--- a/hoomd/mpcd/update.py
+++ b/hoomd/mpcd/update.py
@@ -47,7 +47,7 @@ class ReverseNonequilibriumShearFlow(Updater):
     Up to `num_swaps` swaps are executed each time.
 
     The amount of momentum transferred from the lower slab to the upper slab
-    is accumulated into `summed_exchangeD_momentum`. This quantity can be used
+    is accumulated into `summed_exchanged_momentum`. This quantity can be used
     to calculate the momentum flux and, in conjunction with the shear velocity
     field that is generated, determine the shear viscosity.
 

--- a/hoomd/mpcd/update.py
+++ b/hoomd/mpcd/update.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+r"""MPCD updaters.
+
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
+
+"""
+
+from . import _mpcd
+from hoomd.operation import Updater
+from hoomd.data.parameterdicts import ParameterDict
+from hoomd.logging import log
+from hoomd.data.typeconverter import OnlyTypes, positive_real
+
+import math
+
+
+class ReverseNonequilibriumShearFlow(Updater):
+    r"""MPCD reverse nonequilibrium shear flow.
+
+    Args:
+        trigger (hoomd.trigger.trigger_like): Trigger to swap momentum.
+
+        num_swaps (int): Maximum number of times to swap momentum per update.
+
+        slab_width (float): Width of momentum-exchange slabs.
+
+        target_momentum (float): Target momentum for swapped particles. This
+            argument has a default value of infinity but can be
+            redefined with positive real numbers only.
+
+    This updater generates a bidirectional shear flow in *x* by imposing a
+    momentum flux on the system in *y*.
+    There are two exchange slabs separated by a distance of :math:`L_y/2`. The
+    edges of these slabs are located at (:math:`-L_y/2`, :math:`-L_y/2` +
+    `slab_width`) and (:math:`0.0`, `slab_width`) along the *y*-direction
+    (gradient direction) of the simulation box. On each `trigger`, particles
+    are sorted into the exchange slabs based on their positions in the box.
+    Particles whose *x*-component momenta are near `target_momentum`
+    in the lower slab, and those near -`target_momentum` in the upper
+    slab, are selected for a pairwise momentum swap. Up to `num_swaps` swaps
+    are executed per update.
+
+    The amount of momentum transferred from the lower slab to the upper slab is
+    known. Therefore `summed_exchanged_momentum`, which returns the accumulated
+    momentum exchanged till the current timestep, is used to calculate the
+    momentum flux, :math:`j_{xy}`. The shear rate, :math:`\dot{\gamma}`, is
+    also extracted as the gradient of the linear velocity profile developed
+    from the flow. The viscosity can then be computed from these two quantities
+    as:
+
+    .. math::
+
+        \eta (\dot{\gamma}) = \frac{j_{xy}}{\dot{\gamma}}.
+
+    .. rubric:: Examples:
+
+    In the original implementation by
+    `Müller-Plathe <https://doi.org/10.1103/PhysRevE.59.4894>`_,
+    only the fastest particle and the slowest particle are swapped. This is
+    achieved by setting `num_swaps` to 1 and keeping `target_momentum` at its
+    default value of infinity.
+
+    .. code-block:: python
+
+            flow = hoomd.mpcd.update.ReverseNonequilibriumShearFlow(
+                trigger=1, num_swaps=1, slab_width=1
+            )
+            simulation.operations.updaters.append(flow)
+
+    An alternative approach proposed by
+    `Tenney and Maginn <https://doi.org/10.1063/1.3276454>`_ swaps particles
+    that are instead closest to the `target_momentum`, typically requiring more
+    swaps per update.
+
+    .. code-block:: python
+
+            flow = hoomd.mpcd.update.ReverseNonequilibriumShearFlow(
+                trigger=1, num_swaps=10, slab_width=1, target_momentum=5
+            )
+            simulation.operations.updaters.append(flow)
+
+    {inherited}
+
+    ----------
+
+    **Members defined in** `ReverseNonequilibriumShearFlow`:
+
+    Attributes:
+        trigger (hoomd.trigger.trigger_like): Trigger to swap momentum.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                flow.trigger = 1
+
+        num_swaps (int): Maximum number of times to swap momentum per update.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                flow.num_swaps = 10
+
+        slab_width (float): Width of momentum-exchange slabs.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                flow.slab_width = 1
+
+        target_momentum (float): Target momentum for swapped particles.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                flow.target_momentum = 5
+
+    """
+
+    __doc__ = __doc__.replace("{inherited}", Updater._doc_inherited)
+
+    # Constructor
+    def __init__(self, trigger, num_swaps, slab_width, target_momentum=math.inf):
+        # Call the parent constructor with the trigger parameter
+        super().__init__(trigger)
+
+        # Create a ParameterDict with the given parameters
+        param_dict = ParameterDict(
+            num_swaps=int(num_swaps),
+            slab_width=float(slab_width),
+            target_momentum=OnlyTypes(float, preprocess=positive_real),
+        )
+        param_dict["target_momentum"] = target_momentum
+
+        # Update the internal parameter dictionary created by the parent class
+        self._param_dict.update(param_dict)
+
+    # Use the _attach_hook method to create the C++ version of the object
+    def _attach_hook(self):
+        sim = self._simulation
+        self._cpp_obj = _mpcd.ReverseNonequilibriumShearFlow(
+            sim.state._cpp_sys_def,
+            self.trigger,
+            self.num_swaps,
+            self.slab_width,
+            self.target_momentum,
+        )
+
+        super()._attach_hook()
+
+    @log(category="scalar", requires_run=True)
+    def summed_exchanged_momentum(self):
+        r"""float: Total momentum exchanged.
+
+        This quantity logs the total momentum exchanged between all swapped
+        particle pairs. The value reported is the total exchanged momentum
+        accumulated till the current timestep.
+
+        """
+        return self._cpp_obj.summed_exchanged_momentum
+
+
+__all__ = [
+    "ReverseNonequilibriumShearFlow",
+]

--- a/sphinx-doc/hoomd/module-mpcd.rst
+++ b/sphinx-doc/hoomd/module-mpcd.rst
@@ -17,6 +17,7 @@ mpcd
     mpcd/module-methods
     mpcd/module-stream
     mpcd/module-tune
+    mpcd/module-update
 
 .. rubric:: Classes
 

--- a/sphinx-doc/hoomd/mpcd/module-update.rst
+++ b/sphinx-doc/hoomd/mpcd/module-update.rst
@@ -1,0 +1,13 @@
+update
+======
+
+.. automodule:: hoomd.mpcd.update
+   :members:
+   :exclude-members: ReverseNonequilibriumShearFlow
+
+.. rubric:: Classes
+
+.. toctree::
+    :maxdepth: 1
+
+    update/reversenonequilibriumshearflow

--- a/sphinx-doc/hoomd/mpcd/update/reversenonequilibriumshearflow.rst
+++ b/sphinx-doc/hoomd/mpcd/update/reversenonequilibriumshearflow.rst
@@ -1,0 +1,8 @@
+ReverseNonequilibriumShearFlow
+==============================
+
+.. py:currentmodule:: hoomd.mpcd.update
+
+.. autoclass:: ReverseNonequilibriumShearFlow
+   :members:
+   :show-inheritance:

--- a/sphinx-doc/module-mpcd-update.rst
+++ b/sphinx-doc/module-mpcd-update.rst
@@ -1,0 +1,21 @@
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+mpcd.update
+-----------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.mpcd.update
+
+.. autosummary::
+    :nosignatures:
+
+    ReverseNonequilibriumShearFlow
+
+.. rubric:: Details
+
+.. automodule:: hoomd.mpcd.update
+    :synopsis: Updaters.
+    :members: ReverseNonequilibriumShearFlow
+    :show-inheritance:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

This PR introduces an MPCD updater to perform reverse nonequilibrium shear flow simulations. 

## Motivation and context

In nonequilibrium shear flow, the shear viscosity can be computed from the imposed velocity gradient and the resulting momentum flux. In cases where the flux slowly converges, the reverse nonequilibrium approach, which rather imposes the flux and measures the generated shear field, provides a powerful alternative for shear viscosity calculations.


## How has this been tested?

Unit tests were added for `mpcd.update.ReverseNonequilibriumShearFlow`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

* `mpcd.update.ReverseNonequilibriumShearFlow` added to perform reverse nonequilibrium shear flow simulations.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
